### PR TITLE
feat: update otlp java demo to loki 3

### DIFF
--- a/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/compose.yml
+++ b/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/compose.yml
@@ -127,7 +127,7 @@ services:
       replicas: 1
 
   loki:
-    image: grafana/loki@sha256:c59b9e928dffd375920b972e936c81e93bf14114c5229fae56a07cc47b15b475 #main with otlp support https://github.com/grafana/loki/pull/10727
+    image: grafana/loki:3.0.0
     command: -config.file=/etc/loki/local-config.yaml -validation.reject-old-samples=false -query-scheduler.max-outstanding-requests-per-tenant=2048 -querier.max-outstanding-requests-per-tenant=2048
     volumes:
       - ./loki/:/etc/loki/:ro

--- a/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/grafana/provisioning/dashboards/Apps/OpenTelemetry JVM Micrometer.json
+++ b/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/grafana/provisioning/dashboards/Apps/OpenTelemetry JVM Micrometer.json
@@ -824,7 +824,7 @@
             "uid": "${loki_ds}"
           },
           "editorMode": "builder",
-          "expr": "{service_name=\"$service_name\", deployment_environment=\"$deployment_environment\", service_instance_id=~\"$host_name\"} |= ``",
+          "expr": "{service_name=\"$service_name\", deployment_environment=\"$deployment_environment\", host_name=~\"$host_name\", service_version=\"$service_version\"}",
           "queryType": "range",
           "refId": "A"
         }
@@ -1723,7 +1723,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1847,7 +1848,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1998,7 +2000,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2124,7 +2127,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2276,7 +2280,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2428,7 +2433,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2554,7 +2560,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2740,7 +2747,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2878,7 +2886,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3003,7 +3012,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3128,7 +3138,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3263,7 +3274,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -3389,7 +3401,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",

--- a/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/grafana/provisioning/datasources/loki.yml
+++ b/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/grafana/provisioning/datasources/loki.yml
@@ -9,6 +9,7 @@ datasources:
     jsonData:
       derivedFields:
         - datasourceUid: tempo
-          matcherRegex: "traceId=(\\w+)"
+          matcherType: label
+          matcherRegex: trace_id
           name: TraceID
           url: '$${__value.raw}'

--- a/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/loki/local-config.yaml
+++ b/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/loki/local-config.yaml
@@ -5,7 +5,19 @@ server:
   http_listen_port: 3100
 
 # otlp config: https://github.com/grafana/loki/blob/main/docs/sources/send-data/otel/_index.md
+# distributor config: https://grafana.com/docs/loki/latest/configure/#distributor
 # PR: https://github.com/grafana/loki/pull/10727
+distributor:
+  otlp_config:
+    # List of default otlp resource attributes to be picked as index labels
+    # CLI flag: -distributor.otlp.default_resource_attributes_as_index_labels
+    default_resource_attributes_as_index_labels: 
+      - service.name
+      - service.namespace
+      - service.version
+      - host.name
+      - deployment.environment
+
 limits_config:
   allow_structured_metadata: true
 
@@ -21,12 +33,19 @@ common:
     kvstore:
       store: inmemory
 
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
 schema_config:
   configs:
     - from: 2020-10-24
-      store: boltdb-shipper
+      store: tsdb
       object_store: filesystem
-      schema: v11
+      schema: v13
       index:
         prefix: index_
         period: 24h
@@ -40,9 +59,9 @@ ruler:
 # Statistics help us better understand how Loki is used, and they show us performance
 # levels for most users. This helps us prioritize features and documentation.
 # For more information on what's sent, look at
-# https://github.com/grafana/loki/blob/main/pkg/usagestats/stats.go
+# https://github.com/grafana/loki/blob/main/pkg/analytics/stats.go
 # Refer to the buildReport method to see what goes into a report.
 #
 # If you would like to disable reporting, uncomment the following lines:
 analytics:
- reporting_enabled: false
+  reporting_enabled: false

--- a/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/otelcontribcol/agent/exporters.yaml
+++ b/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/otelcontribcol/agent/exporters.yaml
@@ -5,5 +5,7 @@ exporters:
     endpoint: http://loki:3100/loki/api/v1/push
     default_labels_enabled:
       level: true
+  otlphttp/gateway/loki:
+    endpoint: http://loki:3100/otlp 
   otlphttp/mimir:
     endpoint: http://mimir:9009/otlp

--- a/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/otelcontribcol/agent/pipeline.app.yaml
+++ b/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/otelcontribcol/agent/pipeline.app.yaml
@@ -4,27 +4,43 @@ receivers:
     storage: file_storage/app
     multiline:
       line_start_pattern: timestamp=
+    operators:
+      - type: key_value_parser
+        delimiter: "="
+        pair_delimiter: "\t"
+      - type: move
+        from: attributes["service.version"]
+        to: resource["service.version"]
+      - type: move
+        from: attributes.message
+        to: body
+      - type: time_parser
+        parse_from: attributes.timestamp
+        layout_type: strptime
+        layout: "%Y-%m-%dT%H:%M:%S.%LZ" #2024-04-11T12:39:13.402Z
+      - type: remove
+        field: attributes.timestamp
+      - type: trace_parser
+        trace_id:
+          parse_from: attributes.traceId
+        span_id:
+          parse_from: attributes.spanId
+      - type: remove
+        field: attributes.traceId
+      - type: remove
+        field: attributes.spanId
     resource:
       service.name: ${env:SERVICE_NAME}
       service.namespace: ${env:SERVICE_NAMESPACE}
       host.name: ${env:HOSTNAME}
       deployment.environment: ${env:DEPLOYMENT_ENVIRONMENT}
-      service.instance.id: ${env:HOSTNAME} # loki does not accept host.name (https://github.com/grafana/loki/issues/11786)
 
 processors:
   batch/app:
-  resource/app/loki:
-    attributes:
-      - action: insert
-        key: loki.resource.labels
-        value: service.name, service.namespace, service.version, host.name, deployment.environment, service.instance.id
-      - action: insert
-        key: loki.format
-        value: raw
 
 service:
   pipelines:
     logs/app:
       receivers: [filelog/app]
-      processors: [batch/app, resource/app/loki]
-      exporters: [loki]
+      processors: [batch/app]
+      exporters: [otlphttp/gateway/loki, debug]

--- a/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/otelcontribcol/gateway/pipeline.logs.yml
+++ b/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/otelcontribcol/gateway/pipeline.logs.yml
@@ -1,13 +1,8 @@
 processors:
-  resource/loki:
-    attributes:
-      - action: upsert
-        key: service.instance.id # loki does not accept host.name (https://github.com/grafana/loki/issues/11786)
-        from_attribute: host.name
-
+  batch/loki:
 service:
   pipelines:
     logs/gateway:
       receivers: [otlp/gateway]
-      processors: [resource/loki]
+      processors: [batch/loki]
       exporters: [otlphttp/gateway/loki]

--- a/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/service/src/main/resources/logback.xml
+++ b/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/service/src/main/resources/logback.xml
@@ -12,7 +12,7 @@
         <file>log/${SERVICE_NAME}.log</file>
         <append>true</append>
         <encoder>
-            <pattern>timestamp=%d{yyyy/MM/dd HH:mm:ss.SSSSSSSSS}\tservice.version=${service.version}\ttraceId=%X{trace_id}\tspanId=%X{span_id}\tmessage=%msg%n</pattern>
+            <pattern>timestamp=%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}\tservice.version=${service.version}\ttraceId=%X{trace_id}\tspanId=%X{span_id}\tmessage=%msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Loki 3 update:
- [x] update loki datasource provisioning by using trace_id label instead of log line regex (https://github.com/grafana/grafana/blob/v10.4.1/public/app/plugins/datasource/loki/types.ts#L57)

Demo update to conform with loki 3:
- [x] use loki v3 docker image
- [x] update loki configuration
- [x] legacy tsv file log scrap: update otelcontribcol agent configuration to parse the logline + update logback config
- [x] replace loki exporter by otlphttp exporter
- [x] remove temporary hack (was an earlier test of otlp integration)
- [x] update log panel dashboard

Here is what it looks like to use the new simplified otlp integration from loki 3:

![image](https://github.com/o11y-weekly/o11y-weekly.github.io/assets/2091863/66730ed0-a113-4b22-815f-0b119d738e3a)

