### PR TITLE
feat: add otlp/loki tempo tracesToLogs integration

### DIFF
--- a/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/compose.yml
+++ b/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/compose.yml
@@ -151,7 +151,7 @@ services:
       - bridge
 
   grafana:
-    image: grafana/grafana-oss:10.3.1
+    image: grafana/grafana-oss:10.4.1
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin

--- a/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/grafana/provisioning/datasources/tempo.yml
+++ b/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/grafana/provisioning/datasources/tempo.yml
@@ -1,6 +1,7 @@
 apiVersion: 1
 
 # https://github.com/grafana/grafana/blob/1ea7dc92508ca51dfb29f54883a2a487f6441395/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.tsx#L31
+# https://grafana.com/docs/grafana/latest/datasources/tempo/configure-tempo-data-source/#custom-query-variables
 datasources:
   - name: Tempo
     type: tempo
@@ -8,13 +9,10 @@ datasources:
     access: proxy
     url: http://tempo:3200
     jsonData:
-      httpMethod: GET
-      tracesToLogs:
+      tracesToLogsV2:
         datasourceUid: 'loki'
-        filterByTraceID: false
-        filterBySpanID: false
         customQuery: true
-        query: '{${__tags}} | trace_id="${__trace.traceId}" | span_id="${__span.spanId}"'
+        query: '{$${__tags}} | trace_id="$${__trace.traceId}" | span_id="$${__span.spanId}"'
       serviceMap:
         datasourceUid: 'mimir'
       search:

--- a/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/grafana/provisioning/datasources/tempo.yml
+++ b/2024-01-31_OpenTelemetry_Looks_Good_To_Me/demo/grafana/provisioning/datasources/tempo.yml
@@ -1,5 +1,6 @@
 apiVersion: 1
 
+# https://github.com/grafana/grafana/blob/1ea7dc92508ca51dfb29f54883a2a487f6441395/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.tsx#L31
 datasources:
   - name: Tempo
     type: tempo
@@ -10,13 +11,10 @@ datasources:
       httpMethod: GET
       tracesToLogs:
         datasourceUid: 'loki'
-        tags: ['application', 'host']
-        mappedTags: [{ key: 'application', value: 'service' }]
-        mapTagNamesEnabled: false
-        spanStartTimeShift: '1h'
-        spanEndTimeShift: '1h'
-        filterByTraceID: true
-        filterBySpanID: true
+        filterByTraceID: false
+        filterBySpanID: false
+        customQuery: true
+        query: '{${__tags}} | trace_id="${__trace.traceId}" | span_id="${__span.spanId}"'
       serviceMap:
         datasourceUid: 'mimir'
       search:


### PR DESCRIPTION
- [x] update grafana to 10.4.1
- [x] change tempo datasource configuration according to the new v2 configuration : 
  - https://grafana.com/docs/grafana/latest/datasources/tempo/configure-tempo-data-source/#provision-the-data-source
  - https://github.com/grafana/grafana/blob/1ea7dc92508ca51dfb29f54883a2a487f6441395/packages/grafana-o11y-ds-frontend/src/TraceToLogs/TraceToLogsSettings.tsx#L31
  - [x] fix example from grafana doc: https://github.com/grafana/grafana/issues/86604


![image](https://github.com/o11y-weekly/o11y-weekly.github.io/assets/2091863/dc0f791f-e544-49de-9ff7-b5684f8231de)



